### PR TITLE
Fix growth boost application bug

### DIFF
--- a/src/components/ads/BoostStatusIndicator.tsx
+++ b/src/components/ads/BoostStatusIndicator.tsx
@@ -25,9 +25,11 @@ export function BoostStatusIndicator({ showInline = false, className = '' }: Boo
 
   const getBoostLabel = (effectType: string, effectValue: number) => {
     switch (effectType) {
-      case 'coin_boost': return `Pièces ×${effectValue}`;
-      case 'gem_boost': return `Gemmes ×${effectValue}`;
-      case 'growth_boost': return `Croissance -${Math.round((1 - (1/effectValue)) * 100)}%`;
+      case 'coin_boost': return `Pièces ×${effectValue.toFixed(1)}`;
+      case 'gem_boost': return `Gemmes ×${effectValue.toFixed(1)}`;
+      case 'growth_boost': 
+        const reductionPercentage = Math.round((1 - effectValue) * 100);
+        return `Croissance -${reductionPercentage}%`;
       default: return 'Boost actif';
     }
   };

--- a/src/components/garden/GameHeader.tsx
+++ b/src/components/garden/GameHeader.tsx
@@ -44,11 +44,18 @@ export const GameHeader = ({ garden }: GameHeaderProps) => {
     }
   };
 
-  const getBoostLabel = (effectType: string) => {
+  const getBoostLabel = (effectType: string, effectValue?: number) => {
     switch (effectType) {
-      case 'coin_boost': return 'Pièces ×2';
-      case 'gem_boost': return 'Gemmes ×1.5';
-      case 'growth_boost': return 'Croissance -50%';
+      case 'coin_boost': 
+        return effectValue ? `Pièces ×${effectValue.toFixed(1)}` : 'Pièces ×2';
+      case 'gem_boost': 
+        return effectValue ? `Gemmes ×${effectValue.toFixed(1)}` : 'Gemmes ×1.5';
+      case 'growth_boost': 
+        if (effectValue) {
+          const reductionPercentage = Math.round((1 - effectValue) * 100);
+          return `Croissance -${reductionPercentage}%`;
+        }
+        return 'Croissance -50%';
       default: return 'Boost';
     }
   };
@@ -173,7 +180,7 @@ export const GameHeader = ({ garden }: GameHeaderProps) => {
                             <span className="text-sm">{getBoostIcon(boost.effect_type)}</span>
                             <div className="flex flex-col min-w-0 flex-1">
                               <span className="mobile-text-xs font-semibold text-orange-700 truncate">
-                                {getBoostLabel(boost.effect_type)}
+                                {getBoostLabel(boost.effect_type, boost.effect_value)}
                               </span>
                               <span className="mobile-text-xs text-orange-600">
                                 {formatTimeRemaining(getTimeRemaining(boost.expires_at))}
@@ -183,7 +190,7 @@ export const GameHeader = ({ garden }: GameHeaderProps) => {
                         </TooltipTrigger>
                         <TooltipContent>
                           <div className="text-center">
-                            <p className="font-semibold">{getBoostLabel(boost.effect_type)}</p>
+                            <p className="font-semibold">{getBoostLabel(boost.effect_type, boost.effect_value)}</p>
                             <p className="text-xs text-muted-foreground">
                               {formatTimeRemaining(getTimeRemaining(boost.expires_at))} restant
                             </p>
@@ -207,7 +214,7 @@ export const GameHeader = ({ garden }: GameHeaderProps) => {
                               <div key={boost.id} className="flex items-center justify-between text-xs border-b border-gray-100 pb-1 last:border-b-0">
                                 <div className="flex items-center space-x-1">
                                   <span>{getBoostIcon(boost.effect_type)}</span>
-                                  <span className="font-medium">{getBoostLabel(boost.effect_type)}</span>
+                                  <span className="font-medium">{getBoostLabel(boost.effect_type, boost.effect_value)}</span>
                                 </div>
                                 <span className="text-muted-foreground">
                                   {formatTimeRemaining(getTimeRemaining(boost.expires_at))}

--- a/src/hooks/useGameMultipliers.ts
+++ b/src/hooks/useGameMultipliers.ts
@@ -33,7 +33,9 @@ export const useGameMultipliers = () => {
     return {
       // Multiplicateurs combinés permanents + temporaires
       harvest: permanentMultipliers.harvest * coinBoost,
-      growth: permanentMultipliers.growth * growthBoost,
+      // FIXED: Les boosts temporaires s'additionnent aux améliorations permanentes
+      // Cela évite l'effet exponentiel qui rendait les plantes trop rapides
+      growth: permanentMultipliers.growth + (growthBoost - 1),
       exp: permanentMultipliers.exp, // Pas de boost temporaire XP pour l'instant
       plantCostReduction: permanentMultipliers.plantCostReduction,
       gemChance: permanentMultipliers.gemChance,

--- a/src/services/EconomyService.ts
+++ b/src/services/EconomyService.ts
@@ -133,7 +133,9 @@ export class EconomyService {
           multipliers.harvest *= levelUpgrade.effect_value;
           break;
         case 'growth_speed':
-          multipliers.growth *= levelUpgrade.effect_value;
+          // FIXED: Les améliorations de croissance s'additionnent au lieu de se multiplier
+          // Cela évite l'effet exponentiel qui rendait les plantes trop rapides
+          multipliers.growth += (levelUpgrade.effect_value - 1);
           break;
         case 'exp_multiplier':
           multipliers.exp *= levelUpgrade.effect_value;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adjust growth multiplier calculation to prevent exponential speed reduction from combined permanent upgrades and temporary boosts.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, both permanent growth upgrades and temporary growth boosts were applied multiplicatively, leading to an unintended exponential reduction in plant growth time (e.g., potatoes growing in 30 seconds). This PR changes the calculation to be additive, ensuring a balanced and realistic growth rate when multiple multipliers are active.

---

[Open in Web](https://cursor.com/agents?id=bc-1e91ddee-4674-49a8-b331-8b4d41baef24) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1e91ddee-4674-49a8-b331-8b4d41baef24) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)