### PR TITLE
Corriger le bug d'affichage post-commit

### DIFF
--- a/PR_CREATION_SUMMARY.md
+++ b/PR_CREATION_SUMMARY.md
@@ -1,0 +1,70 @@
+# 🚀 Création de Pull Request - Résumé
+
+## ✅ Travail effectué
+
+### 🐛 Corrections apportées
+1. **Bug d'affichage des temps de croissance** - Corrigé dans `src/services/PlantGrowthService.ts`
+2. **Notification redondante supprimée** - Supprimé dans `src/hooks/useDirectPlanting.ts`
+
+### 📝 Commits créés
+- `2cd414e` - 🐛 Fix: Correction du bug d'affichage après refactoring du système de croissance
+- `c884443` - 🔇 Remove: Suppression de la notification 'Plante plantée avec succès'
+- `c5604e6` - 📝 Add PR description for bug fixes
+
+### 🌿 Branche poussée
+- **Nom** : `cursor/corriger-le-bug-d-affichage-post-commit-051f`
+- **Statut** : ✅ Poussée vers origin avec succès
+
+## 🔗 URL pour créer la PR manuellement
+
+**Cliquez sur ce lien pour créer la Pull Request :**
+
+https://github.com/Shweepsi/grow-garden-verse/pull/new/cursor/corriger-le-bug-d-affichage-post-commit-051f
+
+## 📋 Informations pour la PR
+
+### Titre suggéré
+```
+🐛 Fix: Correction du bug d'affichage post-refactoring + Suppression notification redondante
+```
+
+### Description suggérée
+```
+Cette PR corrige un bug critique qui empêchait l'affichage correct des temps de croissance depuis le refactoring du système de croissance, et supprime une notification redondante pour améliorer l'UX.
+
+## 🐛 Problèmes résolus
+
+### 1. Bug d'affichage des temps de croissance
+- **Problème** : La méthode `formatTimeRemaining` du `PlantGrowthService` ne retournait plus une chaîne formatée mais un nombre
+- **Cause** : L'alias pointait vers `getTimeRemaining()` qui retourne des secondes (number)
+- **Impact** : Les composants affichaient des nombres au lieu de temps formatés
+
+### 2. Notification redondante
+- **Problème** : Toast "Plante plantée avec succès !" apparaissait à chaque plantation
+- **Impact** : Expérience utilisateur dégradée
+
+## ✅ Solutions implémentées
+
+1. **Correction de formatTimeRemaining** : Utilise maintenant `GrowthService.formatTimeRemaining` pour un formatage cohérent
+2. **Suppression de la notification** : Plus de toast redondant lors de la plantation
+
+## 📁 Fichiers modifiés
+- `src/services/PlantGrowthService.ts` - Correction de la méthode formatTimeRemaining
+- `src/hooks/useDirectPlanting.ts` - Suppression de la notification redondante
+
+## 🧪 Tests effectués
+- ✅ Compilation réussie (`npm run build`)
+- ✅ Application démarre sans erreurs
+- ✅ Pas d'erreurs TypeScript
+```
+
+## 🔧 Limitation technique
+
+**Note** : La création automatique via GitHub CLI a échoué en raison des permissions limitées du token `cursor[bot]`. La branche a été poussée avec succès et peut être utilisée pour créer manuellement la PR via l'interface web GitHub.
+
+## ⚡ Prochaine étape
+
+1. Cliquer sur l'URL ci-dessus
+2. Copier-coller le titre et la description suggérés
+3. Créer la Pull Request
+4. Merger après review si nécessaire

--- a/src/hooks/useDirectPlanting.ts
+++ b/src/hooks/useDirectPlanting.ts
@@ -174,7 +174,6 @@ export const useDirectPlanting = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['gameData'] });
-      toast.success('Plante plantée avec succès !');
     },
     onError: (error: any) => {
       console.error('💥 Erreur lors de la plantation directe:', error);

--- a/src/services/PlantGrowthService.ts
+++ b/src/services/PlantGrowthService.ts
@@ -94,7 +94,11 @@ export class PlantGrowthService {
 
   // Aliases pour compatibilité avec le code existant
   static isPlantReady = PlantGrowthService.isReadyToHarvest;
-  static formatTimeRemaining = PlantGrowthService.getTimeRemaining;
+  
+  static formatTimeRemaining(plantedAt: string, growthTimeSeconds: number, boosts?: { getBoostMultiplier: (type: string) => number }): string {
+    const seconds = PlantGrowthService.getTimeRemaining(plantedAt, growthTimeSeconds, boosts);
+    return GrowthService.formatTimeRemaining(seconds);
+  }
   
   static calculateGrowthProgress(plantedAt: string, growthTimeSeconds: number, boosts?: { getBoostMultiplier: (type: string) => number }): number {
     // Convert old boost interface to new GrowthModifiers


### PR DESCRIPTION
Corrige l'affichage du temps de croissance et supprime une notification de plantation redondante.

Le refactoring du système de croissance avait introduit un bug où `PlantGrowthService.formatTimeRemaining` retournait un nombre au lieu d'une chaîne formatée, empêchant l'affichage correct des temps. Cette PR corrige la méthode pour utiliser le nouveau `GrowthService` et supprime également une notification "Plante plantée avec succès" pour améliorer l'expérience utilisateur.

---

[Open in Web](https://cursor.com/agents?id=bc-250ac754-35bd-4cfc-b28f-6c67f8281f69) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-250ac754-35bd-4cfc-b28f-6c67f8281f69) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)