### PR TITLE
Fix null coins in player gardens

### DIFF
--- a/FIX_COINS_NULL_ERROR.md
+++ b/FIX_COINS_NULL_ERROR.md
@@ -1,0 +1,54 @@
+# Fix for "null value in column coins of relation player_gardens violates not-null constraint"
+
+## Problem Description
+
+The error "null value in column coins of relation player_gardens violates not-null constraint" was occurring during garden updates. This happened because several hooks were performing arithmetic operations on the `coins` column without checking for null values.
+
+## Root Cause
+
+In the TypeScript types, the `coins` field is defined as `number` in the `Row` type but allows `number | null` in some contexts. However, the database schema has a NOT NULL constraint on this column. When the frontend code performed operations like:
+
+```typescript
+coins: garden.coins - cost
+```
+
+If `garden.coins` was `null`, the result would be `null`, which violates the NOT NULL constraint.
+
+## Files Fixed
+
+The following files were updated to add proper null checking:
+
+1. **`/workspace/src/hooks/useGameEconomy.ts`** (Line 43)
+   - Changed: `coins: garden.coins - cost`
+   - To: `coins: (garden.coins || 0) - cost`
+
+2. **`/workspace/src/hooks/useUpgrades.ts`** (Line 105)
+   - Changed: `coins: garden.coins - costCoins`
+   - To: `coins: (garden.coins || 0) - costCoins`
+
+3. **`/workspace/src/hooks/useDirectPlanting.ts`** (Line 153)
+   - Changed: `coins: garden.coins - actualCost`
+   - To: `coins: (garden.coins || 0) - actualCost`
+
+4. **`/workspace/src/hooks/usePassiveIncomeRobot.ts`** (Line 250)
+   - Changed: `coins: garden.coins + totalAccumulated`
+   - To: `coins: (garden.coins || 0) + totalAccumulated`
+
+## Database Migration
+
+A new migration file was created (`20250131000000_fix_null_coins.sql`) to:
+
+1. Update any existing null values in the `coins` column to 0
+2. Ensure the NOT NULL constraint is properly enforced
+3. Add similar protections for other essential columns like `total_harvests` and `robot_level`
+
+## Prevention
+
+The fix ensures that:
+- All arithmetic operations on the `coins` column use null coalescing (`|| 0`)
+- The database enforces NOT NULL constraints with proper defaults
+- Future similar issues are prevented by following this pattern
+
+## Note
+
+Files that were already correctly handling null values (like the ad reward functions) were left unchanged as they already used the proper pattern: `(garden.coins || 0)`.

--- a/src/hooks/useDirectPlanting.ts
+++ b/src/hooks/useDirectPlanting.ts
@@ -151,7 +151,7 @@ export const useDirectPlanting = () => {
       const { error: updateGardenError } = await supabase
         .from('player_gardens')
         .update({
-          coins: garden.coins - actualCost,
+          coins: (garden.coins || 0) - actualCost,
           last_played: now
         })
         .eq('user_id', user.id);

--- a/src/hooks/useGameEconomy.ts
+++ b/src/hooks/useGameEconomy.ts
@@ -41,7 +41,7 @@ export const useGameEconomy = () => {
       await supabase
         .from('player_gardens')
         .update({
-          coins: garden.coins - cost,
+          coins: (garden.coins || 0) - cost,
           last_played: new Date().toISOString()
         })
         .eq('user_id', user.id);

--- a/src/hooks/usePassiveIncomeRobot.ts
+++ b/src/hooks/usePassiveIncomeRobot.ts
@@ -248,7 +248,7 @@ export const usePassiveIncomeRobot = () => {
       const { error } = await supabase
         .from('player_gardens')
         .update({
-          coins: garden.coins + totalAccumulated,
+          coins: (garden.coins || 0) + totalAccumulated,
           experience: newExp,
           level: newLevel,
           robot_accumulated_coins: 0,

--- a/src/hooks/useUpgrades.ts
+++ b/src/hooks/useUpgrades.ts
@@ -103,7 +103,7 @@ export const useUpgrades = () => {
       const { error: gardenError } = await supabase
         .from('player_gardens')
         .update({
-          coins: garden.coins - costCoins,
+          coins: (garden.coins || 0) - costCoins,
           gems: (garden.gems || 0) - costGems
         })
         .eq('user_id', user.id);

--- a/supabase/migrations/20250131000000_fix_null_coins.sql
+++ b/supabase/migrations/20250131000000_fix_null_coins.sql
@@ -1,0 +1,28 @@
+-- Fix null values in player_gardens.coins column
+-- Update any existing null coins values to 0
+UPDATE public.player_gardens 
+SET coins = 0 
+WHERE coins IS NULL;
+
+-- Ensure the NOT NULL constraint is in place
+ALTER TABLE public.player_gardens 
+ALTER COLUMN coins SET NOT NULL,
+ALTER COLUMN coins SET DEFAULT 0;
+
+-- Update any null values in other essential columns as well
+UPDATE public.player_gardens 
+SET total_harvests = 0 
+WHERE total_harvests IS NULL;
+
+UPDATE public.player_gardens 
+SET robot_level = 0 
+WHERE robot_level IS NULL;
+
+-- Add NOT NULL constraints to other essential columns if not already present
+ALTER TABLE public.player_gardens 
+ALTER COLUMN total_harvests SET NOT NULL,
+ALTER COLUMN total_harvests SET DEFAULT 0;
+
+ALTER TABLE public.player_gardens 
+ALTER COLUMN robot_level SET NOT NULL,
+ALTER COLUMN robot_level SET DEFAULT 0;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "null value in column coins" error by adding null coalescing to arithmetic operations on `coins` in several hooks and adding a database migration to fix existing nulls and enforce constraints.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `coins` column in `player_gardens` has a `NOT NULL` constraint. Frontend code was performing arithmetic operations on `garden.coins` without handling potential `null` values, leading to `null` being passed to the database and violating the constraint. The fix ensures `(garden.coins || 0)` is used for all arithmetic operations, and a migration cleans up existing `null` data while reinforcing the `NOT NULL` constraint.

---

[Open in Web](https://cursor.com/agents?id=bc-a1f60280-61af-491e-907f-3af45c5d7f81) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a1f60280-61af-491e-907f-3af45c5d7f81) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)