### PR TITLE
Fix null coins in player gardens

### DIFF
--- a/src/hooks/usePlantActions.ts
+++ b/src/hooks/usePlantActions.ts
@@ -114,9 +114,10 @@ export const usePlantActions = () => {
       
       const harvestReward = EconomyService.getHarvestReward(
         plantType.level_required,
-        plantType.rarity,
+        baseGrowthSeconds,        // Temps de croissance de la plante
         playerLevel,
         harvestMultiplier,
+        plantCostReduction,       // Réduction de coût appliquée
         garden.permanent_multiplier || 1
       );
       


### PR DESCRIPTION
Fixes `null` value in `coins` column by correcting parameters passed to `getHarvestReward`.

The `getHarvestReward` function was incorrectly passed `plantType.rarity` (a string) instead of `baseGrowthSeconds` and `plantCostReduction`. This resulted in `NaN` values for the harvest reward, which were then converted to `null` when attempting to update the `coins` column in the database, violating the `NOT NULL` constraint.

---

[Open in Web](https://cursor.com/agents?id=bc-aaf48b03-ff16-4f19-b20f-91876be51c6c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-aaf48b03-ff16-4f19-b20f-91876be51c6c) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)