### PR TITLE
Fix plant time after selection

### DIFF
--- a/src/components/garden/PlantDisplay.tsx
+++ b/src/components/garden/PlantDisplay.tsx
@@ -3,7 +3,7 @@ import { PlantType } from '@/types/game';
 import { PlantGrowthService } from '@/services/PlantGrowthService';
 import { PlantTimer } from './PlantTimer';
 import { Progress } from '@/components/ui/progress';
-import { useActiveBoosts } from '@/hooks/useActiveBoosts';
+import { useGameMultipliers } from '@/hooks/useGameMultipliers';
 
 interface PlantDisplayProps {
   plantType: PlantType;
@@ -16,7 +16,7 @@ export const PlantDisplay = memo(({
   plantedAt,
   growthTimeSeconds
 }: PlantDisplayProps) => {
-  const { getBoostMultiplier } = useActiveBoosts();
+  const { getCombinedBoostMultiplier } = useGameMultipliers();
   const [progress, setProgress] = useState(0);
   const [isReady, setIsReady] = useState(false);
 
@@ -32,7 +32,7 @@ export const PlantDisplay = memo(({
     if (!plantedAt) return;
     
     const updateProgress = () => {
-      const boosts = { getBoostMultiplier };
+      const boosts = { getBoostMultiplier: getCombinedBoostMultiplier };
       // CRITICAL: Utiliser le temps de base de la plante plutôt que le temps stocké
       // pour que les boosts s'appliquent aux plantes existantes
       const baseGrowthTime = plantType.base_growth_seconds || 60;
@@ -52,7 +52,7 @@ export const PlantDisplay = memo(({
     const interval = setInterval(updateProgress, updateInterval);
     
     return () => clearInterval(interval);
-  }, [plantedAt, plantType.base_growth_seconds, getBoostMultiplier]);
+  }, [plantedAt, plantType.base_growth_seconds, getCombinedBoostMultiplier]);
   const getRarityColor = (rarity?: string) => {
     switch (rarity) {
       case 'mythic':

--- a/src/components/garden/PlantTimer.tsx
+++ b/src/components/garden/PlantTimer.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { PlantGrowthService } from '@/services/PlantGrowthService';
 import { Clock } from 'lucide-react';
-import { useActiveBoosts } from '@/hooks/useActiveBoosts';
+import { useGameMultipliers } from '@/hooks/useGameMultipliers';
 
 interface PlantTimerProps {
   plantedAt: string | null;
@@ -11,7 +11,7 @@ interface PlantTimerProps {
 }
 
 export const PlantTimer = ({ plantedAt, growthTimeSeconds, className = "" }: PlantTimerProps) => {
-  const { getBoostMultiplier } = useActiveBoosts();
+  const { getCombinedBoostMultiplier } = useGameMultipliers();
   const [timeRemaining, setTimeRemaining] = useState(0);
   const [isReady, setIsReady] = useState(false);
 
@@ -25,7 +25,7 @@ export const PlantTimer = ({ plantedAt, growthTimeSeconds, className = "" }: Pla
     if (!plantedAt) return;
 
     const updateTimer = () => {
-      const boosts = { getBoostMultiplier };
+      const boosts = { getBoostMultiplier: getCombinedBoostMultiplier };
       
       const remaining = PlantGrowthService.getTimeRemaining(plantedAt, growthTimeSeconds, boosts);
       const ready = PlantGrowthService.isPlantReady(plantedAt, growthTimeSeconds, boosts);
@@ -40,7 +40,7 @@ export const PlantTimer = ({ plantedAt, growthTimeSeconds, className = "" }: Pla
     const interval = setInterval(updateTimer, updateInterval);
 
     return () => clearInterval(interval);
-  }, [plantedAt, growthTimeSeconds, updateInterval, getBoostMultiplier]);
+  }, [plantedAt, growthTimeSeconds, updateInterval, getCombinedBoostMultiplier]);
 
   if (!plantedAt || isReady) return null;
 

--- a/src/components/garden/PlotCard.tsx
+++ b/src/components/garden/PlotCard.tsx
@@ -6,7 +6,7 @@ import { Lock, Sprout, Gift } from 'lucide-react';
 import { PlantDisplay } from './PlantDisplay';
 import { PlantGrowthService } from '@/services/PlantGrowthService';
 import { EconomyService } from '@/services/EconomyService';
-import { useActiveBoosts } from '@/hooks/useActiveBoosts';
+import { useGameMultipliers } from '@/hooks/useGameMultipliers';
 
 interface PlotCardProps {
   plot: GardenPlot;
@@ -31,18 +31,18 @@ export const PlotCard = memo(({
   onPlotClick,
   onUnlockPlot
 }: PlotCardProps) => {
-  const { getBoostMultiplier } = useActiveBoosts();
+  const { getCombinedBoostMultiplier } = useGameMultipliers();
   
   // Memoiser le calcul de l'état de la plante pour éviter les recalculs
   const plantState = useMemo(() => {
     if (!plot.plant_type || !plantType) return 'empty';
-    const boosts = { getBoostMultiplier };
+    const boosts = { getBoostMultiplier: getCombinedBoostMultiplier };
     
     // CRITICAL: Utiliser le temps de base de la plante pour que les boosts s'appliquent
     const baseGrowthTime = plantType.base_growth_seconds || 60;
     const isReady = PlantGrowthService.isPlantReady(plot.planted_at, baseGrowthTime, boosts);
     return isReady ? 'ready' : 'growing';
-  }, [plot.plant_type, plot.planted_at, plantType?.base_growth_seconds, getBoostMultiplier]);
+  }, [plot.plant_type, plot.planted_at, plantType?.base_growth_seconds, getCombinedBoostMultiplier]);
 
   // Memoiser le calcul du coût de déblocage
   const unlockCost = useMemo(() => {

--- a/src/components/garden/PlotGrid.tsx
+++ b/src/components/garden/PlotGrid.tsx
@@ -8,7 +8,7 @@ import { useDirectPlanting } from '@/hooks/useDirectPlanting';
 import { usePassiveIncomeRobot } from '@/hooks/usePassiveIncomeRobot';
 import { toast } from 'sonner';
 import { PlantGrowthService } from '@/services/PlantGrowthService';
-import { useActiveBoosts } from '@/hooks/useActiveBoosts';
+import { useGameMultipliers } from '@/hooks/useGameMultipliers';
 
 interface PlotGridProps {
   plots: GardenPlot[];
@@ -30,7 +30,7 @@ export const PlotGrid = ({
   const [showRobotInterface, setShowRobotInterface] = useState(false);
   
   const { plantDirect, isPlantingPlot } = useDirectPlanting();
-  const { getBoostMultiplier } = useActiveBoosts();
+  const { getCombinedBoostMultiplier } = useGameMultipliers();
   const { 
     hasPassiveRobot, 
     robotPlantType,
@@ -75,7 +75,7 @@ export const PlotGrid = ({
     if (hasPlant && plot.planted_at) {
       const plantType = plantTypeMap.get(plot.plant_type || '');
       if (plantType) {
-        const boosts = { getBoostMultiplier };
+        const boosts = { getBoostMultiplier: getCombinedBoostMultiplier };
         const baseGrowthTime = plantType.base_growth_seconds || 60;
         
         isReady = PlantGrowthService.isPlantReady(plot.planted_at, baseGrowthTime, boosts);
@@ -89,7 +89,7 @@ export const PlotGrid = ({
       // Feedback immédiat optimiste
       onHarvestPlant(plot.plot_number);
     }
-  }, [hasPassiveRobot, onHarvestPlant, plantTypeMap, getBoostMultiplier]);
+  }, [hasPassiveRobot, onHarvestPlant, plantTypeMap, getCombinedBoostMultiplier]);
 
   // Optimiser les handlers de sélection
   const handlePlantSelection = useCallback((plotNumber: number, plantTypeId: string, cost: number) => {

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -4,12 +4,12 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/useAuth';
 import { useEffect } from 'react';
 import { PlantGrowthService } from '@/services/PlantGrowthService';
-import { useActiveBoosts } from '@/hooks/useActiveBoosts';
+import { useGameMultipliers } from '@/hooks/useGameMultipliers';
 
 export const useGameData = () => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const { getBoostMultiplier } = useActiveBoosts();
+  const { getCombinedBoostMultiplier } = useGameMultipliers();
 
   // Configuration du realtime pour garden_plots et player_gardens
   useEffect(() => {
@@ -89,7 +89,7 @@ export const useGameData = () => {
       if (!data?.plots) return 5000; // 5 secondes par défaut
       
       // Créer un objet boosts pour PlantGrowthService
-      const boosts = { getBoostMultiplier };
+      const boosts = { getBoostMultiplier: getCombinedBoostMultiplier };
       
       // Vérifier s'il y a des plantes qui poussent (en tenant compte des boosts)
       const growingPlants = data.plots.filter(plot => {

--- a/src/hooks/useGameMultipliers.ts
+++ b/src/hooks/useGameMultipliers.ts
@@ -53,6 +53,41 @@ export const useGameMultipliers = () => {
       gems: gemBoost
     };
   };
+  
+  /**
+   * Return the FINAL multiplier that should be applied for a given effect type.
+   * This helper merges the permanent multipliers coming from upgrades with any
+   * temporary boost that might currently be active so that callers do not need
+   * to worry about combining them manually. Only the effect types that are
+   * presently used in the codebase are handled – other values default to 1.
+   */
+  const getCombinedBoostMultiplier = (effectType: string): number => {
+    const multipliers = getCompleteMultipliers();
+
+    switch (effectType) {
+      case 'growth_speed':
+      case 'growth_boost':
+        return multipliers.growth;
+
+      case 'harvest_multiplier':
+        return multipliers.harvest;
+
+      case 'exp_multiplier':
+        return multipliers.exp;
+
+      case 'plant_cost_reduction':
+        return multipliers.plantCostReduction;
+
+      case 'coin_boost':
+        return multipliers.coins;
+
+      case 'gem_boost':
+        return multipliers.gems;
+
+      default:
+        return 1;
+    }
+  };
 
   const applyAllBoosts = (coins: number, gems: number) => {
     return {
@@ -64,6 +99,9 @@ export const useGameMultipliers = () => {
   return {
     getCompleteMultipliers,
     applyAllBoosts,
+    // New unified helper so that external code (growth timers, etc.) can use
+    // the same source of truth for multipliers.
+    getCombinedBoostMultiplier,
     // Fonctions individuelles pour la compatibilité
     getBoostMultiplier,
     applyCoinsBoost,

--- a/src/hooks/usePlantActions.ts
+++ b/src/hooks/usePlantActions.ts
@@ -8,14 +8,13 @@ import { EconomyService } from '@/services/EconomyService';
 import { useUpgrades } from '@/hooks/useUpgrades';
 import { useAnimations } from '@/contexts/AnimationContext';
 import { useGameMultipliers } from '@/hooks/useGameMultipliers';
-import { useActiveBoosts } from '@/hooks/useActiveBoosts';
 import { MAX_PLOTS } from '@/constants';
 
 export const usePlantActions = () => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const { getCompleteMultipliers, applyAllBoosts } = useGameMultipliers();
-  const { getBoostMultiplier } = useActiveBoosts();
+  const { getCompleteMultipliers, applyAllBoosts, getCombinedBoostMultiplier } = useGameMultipliers();
+  // getCombinedBoostMultiplier already includes permanent + active boosts
   const { triggerCoinAnimation, triggerXpAnimation, triggerGemAnimation } = useAnimations();
 
   const harvestPlantMutation = useMutation({
@@ -73,7 +72,7 @@ export const usePlantActions = () => {
       // Vérification robuste de la maturité avec application des boosts
       // CRITICAL: Les plantes existantes doivent bénéficier des boosts actifs
       const baseGrowthTime = plantType.base_growth_seconds || 60;
-      const boosts = { getBoostMultiplier };
+      const boosts = { getBoostMultiplier: getCombinedBoostMultiplier };
       const isReady = PlantGrowthService.isPlantReady(plot.planted_at, baseGrowthTime, boosts);
       
       if (!isReady) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Unify plant growth time calculation to correctly apply both permanent upgrades and temporary boosts.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `PlantSelector` correctly displayed growth times by combining permanent multipliers and active boosts. However, after a plant was placed, all growth mechanics only considered active boosts, ignoring permanent upgrades. This PR introduces a `getCombinedBoostMultiplier` in `useGameMultipliers` to ensure all growth-related calculations consistently use the total multiplier (permanent * temporary), matching the `PlantSelector` preview.

---

[Open in Web](https://cursor.com/agents?id=bc-f407a3f0-0121-4dba-b582-892785ee86bd) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f407a3f0-0121-4dba-b582-892785ee86bd) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)