### PR TITLE
Fix growth advertising reward assignment

### DIFF
--- a/src/services/AdRewardService.ts
+++ b/src/services/AdRewardService.ts
@@ -64,6 +64,13 @@ export class AdRewardService {
           amount = config.max_amount;
         }
 
+        // NORMALISATION: pour "growth_speed", garantir un multiplicateur >= 1
+        // Historiquement, les valeurs <1 (ex: 0.5) représentaient une réduction de 50%.
+        // Le moteur de calcul client attend désormais un multiplicateur >1 (ex: 2.0).
+        if (normalizedType === 'growth_speed' && amount < 1 && amount > 0) {
+          amount = 1 / amount;
+        }
+
         // Formater la description selon le type
         let description = config.description;
         if (normalizedType === 'coins' || normalizedType === 'gems') {

--- a/supabase/functions/validate-ad-reward/index.ts
+++ b/supabase/functions/validate-ad-reward/index.ts
@@ -644,7 +644,15 @@ Deno.serve(async (req) => {
       )
     }
     
-    const calculatedAmount = rewardConfig.calculated_amount
+    let calculatedAmount = rewardConfig.calculated_amount
+
+    // NORMALISATION: pour les boosts de croissance, garantir un multiplicateur >= 1
+    // Certains anciens enregistrements stockaient des valeurs <1 (ex: 0.5) pour signifier « 50% plus rapide ».
+    // Le moteur utilise désormais un multiplicateur >1 (ex: 2). Si nécessaire, inverser la valeur.
+    if (payload.reward_type === 'growth_speed' && calculatedAmount < 1 && calculatedAmount > 0) {
+      calculatedAmount = 1 / calculatedAmount
+    }
+
     const durationMinutes = rewardConfig.duration_minutes || 30
     
     // NOUVELLE LOGIQUE: Différentiation entre récompenses immédiates et différées


### PR DESCRIPTION
Normalise growth speed boost values to ensure they are always >= 1, fixing incorrect ad reward attribution.

Historically, `growth_speed` values less than 1 (e.g., 0.5) represented a speed increase (e.g., 50% faster). The client-side calculation engine now expects a multiplier greater than 1 (e.g., 2 for 2x speed). This change inverts the values where necessary so that the stored multiplier correctly reflects the speed increase and the UI displays accurate percentages.

---

[Open in Web](https://cursor.com/agents?id=bc-88969e51-dfc5-4d93-a610-9f1fb8c58fe0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-88969e51-dfc5-4d93-a610-9f1fb8c58fe0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)