### PR TITLE
Fix growth boost ad reward distribution

### DIFF
--- a/supabase/functions/validate-ad-reward/index.ts
+++ b/supabase/functions/validate-ad-reward/index.ts
@@ -629,9 +629,13 @@ Deno.serve(async (req) => {
     
     const playerLevel = garden?.level || 1
     
+    // Si le type est "growth_speed", certaines entrées de configuration peuvent être stockées sous l'alias
+    // "growth_boost" côté base de données. On normalise donc le type utilisé pour la recherche de configuration.
+    const rewardTypeForConfig = payload.reward_type === 'growth_speed' ? 'growth_boost' : payload.reward_type;
+    
     const { data: rewardConfig, error: rewardError } = await supabase
       .rpc('calculate_ad_reward', {
-        reward_type_param: payload.reward_type,
+        reward_type_param: rewardTypeForConfig,
         player_level_param: playerLevel
       })
       .single()


### PR DESCRIPTION
Fix Growth Boost ad reward not being distributed by normalizing reward type for configuration lookup.

---

[Open in Web](https://cursor.com/agents?id=bc-2b9464c3-13b3-434a-8e3b-f5b78e9143e0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2b9464c3-13b3-434a-8e3b-f5b78e9143e0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)