### PR TITLE
Vérifier l'intégration mécanique de la récompense Gem Boost

### DIFF
--- a/src/hooks/usePlantActions.ts
+++ b/src/hooks/usePlantActions.ts
@@ -13,7 +13,7 @@ import { MAX_PLOTS } from '@/constants';
 export const usePlantActions = () => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const { getCompleteMultipliers, applyAllBoosts, getCombinedBoostMultiplier } = useGameMultipliers();
+  const { getCompleteMultipliers, applyAllBoosts, applyGemsBoost, getCombinedBoostMultiplier } = useGameMultipliers();
   // getCombinedBoostMultiplier already includes permanent + active boosts
   const { triggerCoinAnimation, triggerXpAnimation, triggerGemAnimation } = useAnimations();
 
@@ -131,13 +131,16 @@ export const usePlantActions = () => {
         gemChance
       );
 
+      // Appliquer le boost gemmes (gem_boost) si actif
+      const boostedGems = applyGemsBoost(gemReward);
+
       console.log(`💰 Récompenses calculées: ${harvestReward} pièces, ${expReward} EXP, ${gemReward} gemmes`);
       console.log(`🔥 Multiplicateurs appliqués - Récolte: x${harvestMultiplier.toFixed(2)}, EXP: x${expMultiplier.toFixed(2)}, Coût: x${plantCostReduction}, Gemmes: ${(gemChance * 100).toFixed(1)}%`);
 
       const newExp = Math.max(0, (garden.experience || 0) + expReward);
       const newLevel = Math.max(1, Math.floor(Math.sqrt(newExp / 100)) + 1);
       const newCoins = Math.max(0, (garden.coins || 0) + harvestReward);
-      const newGems = Math.max(0, (garden.gems || 0) + gemReward);
+      const newGems = Math.max(0, (garden.gems || 0) + boostedGems);
       const newHarvests = Math.max(0, (garden.total_harvests || 0) + 1);
 
       // Use atomic transaction for better data consistency

--- a/supabase/functions/validate-ad-reward/index.ts
+++ b/supabase/functions/validate-ad-reward/index.ts
@@ -646,6 +646,20 @@ Deno.serve(async (req) => {
     
     let calculatedAmount = rewardConfig.calculated_amount
 
+    // Appliquer le multiplicateur gem_boost si la récompense est de type "gems"
+    if (payload.reward_type === 'gems') {
+      const { data: activeBoost } = await supabase
+        .from('active_effects')
+        .select('effect_value')
+        .eq('user_id', payload.user_id)
+        .eq('effect_type', 'gem_boost')
+        .gt('expires_at', new Date().toISOString())
+        .maybeSingle();
+
+      const gemMultiplier = activeBoost?.effect_value ?? 1;
+      calculatedAmount = Math.floor(calculatedAmount * gemMultiplier);
+    }
+
     // NORMALISATION: pour les boosts de croissance, garantir un multiplicateur >= 1
     // Certains anciens enregistrements stockaient des valeurs <1 (ex: 0.5) pour signifier « 50% plus rapide ».
     // Le moteur utilise désormais un multiplicateur >1 (ex: 2). Si nécessaire, inverser la valeur.


### PR DESCRIPTION
Implement the mechanical application of the Gem Boost reward to all gem income sources, as it was previously stored but not active.

---

[Open in Web](https://cursor.com/agents?id=bc-5972ef9f-8205-45ea-838a-3236eacd0820) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5972ef9f-8205-45ea-838a-3236eacd0820) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)