### PR TITLE
Corriger la vitesse de croissance de la récompense publicitaire

### DIFF
--- a/supabase/functions/validate-ad-reward/index.ts
+++ b/supabase/functions/validate-ad-reward/index.ts
@@ -629,9 +629,9 @@ Deno.serve(async (req) => {
     
     const playerLevel = garden?.level || 1
     
-    // Si le type est "growth_speed", certaines entrées de configuration peuvent être stockées sous l'alias
-    // "growth_boost" côté base de données. On normalise donc le type utilisé pour la recherche de configuration.
-    const rewardTypeForConfig = payload.reward_type === 'growth_speed' ? 'growth_boost' : payload.reward_type;
+    // NORMALISATION: l'alias historique « growth_boost » a été renommé en « growth_speed » dans la BDD.
+    // Si nous recevons encore l'ancien identifiant, on le convertit vers le nouveau pour la recherche.
+    const rewardTypeForConfig = payload.reward_type === 'growth_boost' ? 'growth_speed' : payload.reward_type;
     
     const { data: rewardConfig, error: rewardError } = await supabase
       .rpc('calculate_ad_reward', {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Corrects ad reward type normalization to properly apply `growth_speed` bonuses.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous normalization in `validate-ad-reward` incorrectly mapped `growth_speed` to its old alias `growth_boost` for configuration lookup. Following a database migration where configurations now use `growth_speed`, this mapping caused the lookup to fail and the reward to not be applied. This change inverts the mapping, converting `growth_boost` to `growth_speed` for lookup, ensuring the correct configuration is found and the reward is granted.

---

[Open in Web](https://cursor.com/agents?id=bc-b6e5901f-07d9-47c6-bae1-60b002f9487b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b6e5901f-07d9-47c6-bae1-60b002f9487b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)