### PR TITLE
Corriger la récompense doublée lors de la récolte

### DIFF
--- a/src/components/garden/PlantReadyIndicator.tsx
+++ b/src/components/garden/PlantReadyIndicator.tsx
@@ -32,7 +32,10 @@ export const PlantReadyIndicator = memo(({
         {/* Bouton récolte normale */}
         <Button
           size="sm"
-          onClick={onHarvest}
+          onClick={(e) => {
+            e.stopPropagation(); // Empêche la propagation pour éviter un double déclenchement
+            onHarvest();
+          }}
           className="bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white mobile-text-xs px-3 py-1 h-auto rounded-full shadow-lg transform hover:scale-105 active:scale-95 transition-all duration-200"
         >
           <Gift className="h-3 w-3 mr-1" />
@@ -43,7 +46,10 @@ export const PlantReadyIndicator = memo(({
         {canWatchAd && onWatchAd && (
           <Button
             size="sm"
-            onClick={onWatchAd}
+            onClick={(e) => {
+              e.stopPropagation();
+              onWatchAd();
+            }}
             className="bg-gradient-to-r from-purple-500 to-violet-500 hover:from-purple-600 hover:to-violet-600 text-white mobile-text-xs px-3 py-1 h-auto rounded-full shadow-lg transform hover:scale-105 active:scale-95 transition-all duration-200"
           >
             <Play className="h-3 w-3 mr-1" />


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `e.stopPropagation()` to harvest buttons to prevent double reward collection.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The bug occurred because clicking the harvest buttons (`Récolter` or `Pub ×2`) allowed the click event to propagate to the parent plot container, causing `harvestPlant` to be called a second time, resulting in a doubled reward.

---

[Open in Web](https://cursor.com/agents?id=bc-83139b29-60ed-4fbb-8d21-6b3bb9004dc3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-83139b29-60ed-4fbb-8d21-6b3bb9004dc3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)