### PR TITLE
Fix AdBoost profit display in PlantSelector

### DIFF
--- a/src/components/garden/PlantSelector.tsx
+++ b/src/components/garden/PlantSelector.tsx
@@ -208,7 +208,14 @@ export const PlantSelector = ({
                               </div>
 
                               {/* Profit net */}
-                              
+                              <div
+                                className={`rounded p-1.5 border flex items-center justify-center gap-1 ${profit >= 0 ? 'bg-emerald-50 border-emerald-200 text-emerald-700' : 'bg-yellow-50 border-yellow-200 text-yellow-700'}`}
+                              >
+                                <Award className="h-2.5 w-2.5" />
+                                <div className="text-xs font-bold">
+                                  {profit >= 0 ? '+' : ''}{profit.toLocaleString()}
+                                </div>
+                              </div>
                             </div>
                           </div>
                         </CardContent>


### PR DESCRIPTION
Display net profit in PlantSelector cards to include AdBoost coins in the calculation.

---

[Open in Web](https://cursor.com/agents?id=bc-4b18329f-90b7-495c-87b2-1ebf8dc5b11f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4b18329f-90b7-495c-87b2-1ebf8dc5b11f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)