### PR TITLE
Corriger le boost de pièces appliqué deux fois

### DIFF
--- a/src/hooks/usePlantActions.ts
+++ b/src/hooks/usePlantActions.ts
@@ -13,7 +13,7 @@ import { MAX_PLOTS } from '@/constants';
 export const usePlantActions = () => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const { getCompleteMultipliers, applyAllBoosts, getCombinedBoostMultiplier } = useGameMultipliers();
+  const { getCompleteMultipliers, applyGemsBoost, getCombinedBoostMultiplier } = useGameMultipliers();
   // getCombinedBoostMultiplier already includes permanent + active boosts
   const { triggerCoinAnimation, triggerXpAnimation, triggerGemAnimation } = useAnimations();
 
@@ -207,14 +207,13 @@ export const usePlantActions = () => {
 
       console.log('🏡 Jardin mis à jour avec succès');
 
-      // Appliquer les boosts aux récompenses pour les animations
-      const boostedRewards = applyAllBoosts(harvestReward, gemReward);
-      
-      // Déclencher les animations de récompense avec les montants boostés
-      triggerCoinAnimation(boostedRewards.coins);
+      // Déclencher les animations de récompense
+      // Les pièces ont déjà le boost appliqué via harvestReward
+      triggerCoinAnimation(harvestReward);
       triggerXpAnimation(expReward);
-      if (boostedRewards.gems > 0) {
-        triggerGemAnimation(boostedRewards.gems);
+      const boostedGems = applyGemsBoost(gemReward);
+      if (boostedGems > 0) {
+        triggerGemAnimation(boostedGems);
       }
 
       // Enregistrer la transaction


### PR DESCRIPTION
Fix double application of temporary coin boost during plant harvest.

The coin boost was applied once during the `multipliers.harvest` calculation and again when `applyAllBoosts` was called for the animation. This PR removes the redundant `applyAllBoosts` call for coins, ensuring the boost is applied only once. Gems are now boosted separately via `applyGemsBoost`.

---

[Open in Web](https://cursor.com/agents?id=bc-9b2e8127-49d8-4f12-a682-1f54c3a7ec19) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9b2e8127-49d8-4f12-a682-1f54c3a7ec19) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)