### PR TITLE
Uniformiser le style des barres de scroll

### DIFF
--- a/src/components/ads/AdDiagnosticsPanel.tsx
+++ b/src/components/ads/AdDiagnosticsPanel.tsx
@@ -16,7 +16,7 @@ export function AdDiagnosticsPanel({ debugInfo, onTestConnectivity }: AdDiagnost
         <span className="font-semibold text-red-800">Diagnostics AdMob</span>
       </div>
       <div className="bg-white rounded-lg p-3 border border-red-100 shadow-sm">
-        <pre className="whitespace-pre-wrap overflow-x-auto text-xs text-gray-700 font-mono">
+        <pre className="whitespace-pre-wrap overflow-x-auto pb-1 text-xs text-gray-700 font-mono">
           {JSON.stringify(debugInfo, null, 2)}
         </pre>
       </div>

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -31,14 +31,14 @@ const ScrollBar = React.forwardRef<
     className={cn(
       "flex touch-none select-none transition-colors",
       orientation === "vertical" &&
-        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+        "h-full w-1 border-l border-l-transparent p-[1px]",
       orientation === "horizontal" &&
-        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+        "h-1 flex-col border-t border-t-transparent p-[1px]",
       className
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-gradient-to-b from-green-500/50 to-blue-500/50 hover:from-green-500/70 hover:to-blue-500/70 transition-all duration-300" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ))
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName

--- a/src/pages/GardenPage.tsx
+++ b/src/pages/GardenPage.tsx
@@ -44,7 +44,7 @@ export const GardenPage = () => {
       </div>
       
       {/* Content with padding to avoid overlap */}
-      <div className="px-3 pb-6 space-y-3 h-full overflow-y-auto">
+      <div className="px-3 pb-6 space-y-3 h-full overflow-y-auto pr-1">
         <PlotGrid
           plots={gameState.plots}
           plantTypes={gameState.plantTypes}


### PR DESCRIPTION
Uniformize scrollbar styles across the application to match the `adModal`'s visual style and spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d62d542-40a0-4c94-a317-3a190cd62df6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d62d542-40a0-4c94-a317-3a190cd62df6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>