### PR TITLE
Supprimer les animations d'xp

### DIFF
--- a/src/contexts/AnimationContext.tsx
+++ b/src/contexts/AnimationContext.tsx
@@ -88,7 +88,13 @@ export const AnimationProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   // Générateur de fonctions déclencheurs pour chaque type
   const makeTrigger = (type: FloatingAnimation['type']) =>
-    (amount: number) => setAnimations(prev => [...prev, createAnimation(type, amount, prev)]);
+    (amount: number) => {
+      if (type === 'experience') {
+        // XP animations are disabled. We keep the API surface so calls remain harmless.
+        return;
+      }
+      setAnimations(prev => [...prev, createAnimation(type, amount, prev)]);
+    };
 
   const triggerCoinAnimation = useCallback(makeTrigger('coins'), []);
   const triggerXpAnimation = useCallback(makeTrigger('experience'), []);


### PR DESCRIPTION
Disable XP animations by ignoring the 'experience' type in the animation trigger.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1fd3def-7100-401e-bfcc-6795f4f9611b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1fd3def-7100-401e-bfcc-6795f4f9611b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>