### PR TITLE
Améliorer réactivité plantation récolte et évaluer risques

### DIFF
--- a/src/components/garden/GameHeader.tsx
+++ b/src/components/garden/GameHeader.tsx
@@ -165,10 +165,6 @@ export const GameHeader = ({ garden }: GameHeaderProps) => {
                     Niv. {xpStats.currentLevel}
                   </span>
                 </div>
-                {/* Zone d'animation pour l'XP */}
-                <div className="animation-zone">
-                  {animations.filter(anim => anim.type === 'experience').map(anim => <FloatingNumber key={anim.id} animation={anim} />)}
-                </div>
               </div>
 
               {/* Bouton Publicité - FIXED: using safe state setter */}

--- a/src/contexts/AnimationContext.tsx
+++ b/src/contexts/AnimationContext.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useState, useCallback } from 'react';
 export interface FloatingAnimation {
   id: string;
   amount: number;
-  type: 'coins' | 'experience' | 'gems';
+  type: 'coins' | 'gems';
   timestamp: number;
   row: number; // 0-2
   col: number; // 0-2
@@ -14,7 +14,6 @@ export interface FloatingAnimation {
 interface AnimationContextType {
   animations: FloatingAnimation[];
   triggerCoinAnimation: (amount: number) => void;
-  triggerXpAnimation: (amount: number) => void;
   triggerGemAnimation: (amount: number) => void;
   removeAnimation: (id: string) => void;
 }
@@ -70,7 +69,6 @@ export const AnimationProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     // Ajout d'un offset basé sur le type pour éviter les superpositions
     const typeOffset = {
       'coins': { x: 0, y: 0 },
-      'experience': { x: 5, y: 5 },
       'gems': { x: -5, y: -5 }
     };
 
@@ -89,15 +87,10 @@ export const AnimationProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   // Générateur de fonctions déclencheurs pour chaque type
   const makeTrigger = (type: FloatingAnimation['type']) =>
     (amount: number) => {
-      if (type === 'experience') {
-        // XP animations are disabled. We keep the API surface so calls remain harmless.
-        return;
-      }
       setAnimations(prev => [...prev, createAnimation(type, amount, prev)]);
     };
 
   const triggerCoinAnimation = useCallback(makeTrigger('coins'), []);
-  const triggerXpAnimation = useCallback(makeTrigger('experience'), []);
   const triggerGemAnimation = useCallback(makeTrigger('gems'), []);
 
   const removeAnimation = useCallback((id: string) => {
@@ -108,7 +101,6 @@ export const AnimationProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     <AnimationContext.Provider value={{
       animations,
       triggerCoinAnimation,
-      triggerXpAnimation,
       triggerGemAnimation,
       removeAnimation
     }}>

--- a/src/hooks/useDirectPlanting.ts
+++ b/src/hooks/useDirectPlanting.ts
@@ -243,7 +243,8 @@ export const useDirectPlanting = () => {
           ),
           garden: {
             ...oldData.garden,
-            coins: Math.max(0, (oldData.garden.coins || 0) - data.actualCost)
+            // Les pièces ont déjà été déduites dans onMutate, ne pas les soustraire à nouveau
+            coins: oldData.garden.coins
           }
         };
       });

--- a/src/hooks/usePlantActions.ts
+++ b/src/hooks/usePlantActions.ts
@@ -15,7 +15,7 @@ export const usePlantActions = () => {
   const queryClient = useQueryClient();
   const { getCompleteMultipliers, applyGemsBoost, getCombinedBoostMultiplier } = useGameMultipliers();
   // getCombinedBoostMultiplier already includes permanent + active boosts
-  const { triggerCoinAnimation, triggerXpAnimation, triggerGemAnimation } = useAnimations();
+  const { triggerCoinAnimation, triggerGemAnimation } = useAnimations();
 
   const harvestPlantMutation = useMutation({
     // Optimistic update before the mutation executes
@@ -236,7 +236,6 @@ export const usePlantActions = () => {
       // Déclencher les animations de récompense
       // Les pièces ont déjà le boost appliqué via harvestReward
       triggerCoinAnimation(harvestReward);
-      triggerXpAnimation(expReward);
       const boostedGems = applyGemsBoost(gemReward);
       if (boostedGems > 0) {
         triggerGemAnimation(boostedGems);


### PR DESCRIPTION
Fix double deduction of coins in `useDirectPlanting` to ensure correct balance after optimistic updates.

The `onSuccess` callback for the `plantDirect` mutation was incorrectly re-deducting the cost of planting, even though the `onMutate` optimistic update had already applied the deduction. This led to an inaccurate, lower coin balance for the user. This PR corrects the `onSuccess` logic to no longer deduct coins, relying on the initial optimistic deduction and eventual server-side synchronization.

---
<a href="https://cursor.com/background-agent?bcId=bc-50d830e0-daa2-480c-ace5-7dd03f66d1f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-50d830e0-daa2-480c-ace5-7dd03f66d1f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>