### PR TITLE
Reset scroll on page change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,19 +9,23 @@ import { PrivacyPolicyPage } from '@/pages/legal/PrivacyPolicyPage';
 import { TermsOfServicePage } from '@/pages/legal/TermsOfServicePage';
 import { AboutPage } from '@/pages/legal/AboutPage';
 import NotFound from "./pages/NotFound";
+import { ScrollToTop } from '@/components/layout/ScrollToTop';
 
 const App = () => (
-  <Routes>
-    <Route path="/" element={<Navigate to="/garden" replace />} />
-    <Route path="/garden" element={<AppLayout><GardenPage /></AppLayout>} />
-    <Route path="/upgrades" element={<AppLayout><UpgradesPage /></AppLayout>} />
-    <Route path="/profile" element={<AppLayout><ProfilePage /></AppLayout>} />
-    <Route path="/store" element={<AppLayout><StorePage /></AppLayout>} />
-    <Route path="/privacy" element={<PrivacyPolicyPage />} />
-    <Route path="/terms" element={<TermsOfServicePage />} />
-    <Route path="/about" element={<AboutPage />} />
-    <Route path="*" element={<NotFound />} />
-  </Routes>
+  <>
+    <ScrollToTop />
+    <Routes>
+      <Route path="/" element={<Navigate to="/garden" replace />} />
+      <Route path="/garden" element={<AppLayout><GardenPage /></AppLayout>} />
+      <Route path="/upgrades" element={<AppLayout><UpgradesPage /></AppLayout>} />
+      <Route path="/profile" element={<AppLayout><ProfilePage /></AppLayout>} />
+      <Route path="/store" element={<AppLayout><StorePage /></AppLayout>} />
+      <Route path="/privacy" element={<PrivacyPolicyPage />} />
+      <Route path="/terms" element={<TermsOfServicePage />} />
+      <Route path="/about" element={<AboutPage />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  </>
 );
 
 export default App;

--- a/src/components/layout/ScrollToTop.tsx
+++ b/src/components/layout/ScrollToTop.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Reset the window scroll position to the top on every route change.
+ */
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // Always scroll to the top-left corner when navigating to a new route
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  // This component does not render anything in the DOM
+  return null;
+};


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `ScrollToTop` component to reset scroll position to top on page change.

---
<a href="https://cursor.com/background-agent?bcId=bc-65b2fb74-89e7-4965-9857-b8fcf19a76cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-65b2fb74-89e7-4965-9857-b8fcf19a76cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>