### PR TITLE
Stop floating number animation refresh on page change

### DIFF
--- a/src/components/animations/FloatingNumber.tsx
+++ b/src/components/animations/FloatingNumber.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Coins, Star } from 'lucide-react';
 import { FloatingAnimation, useAnimations } from '@/contexts/AnimationContext';
 
@@ -10,13 +10,29 @@ interface FloatingNumberProps {
 export const FloatingNumber: React.FC<FloatingNumberProps> = ({ animation }) => {
   const { removeAnimation } = useAnimations();
 
+  // Durée totale de l'animation (doit rester cohérente avec celle définie dans le CSS)
+  const DURATION_MS = 2000;
+
+  // Calcule le temps écoulé depuis la création de l'animation
+  const elapsed = useMemo(() => Date.now() - animation.timestamp, [animation.timestamp]);
+
   useEffect(() => {
+    const remaining = DURATION_MS - elapsed;
+
+    // Si l'animation a déjà expiré (par exemple pendant un long changement de page),
+    // on la retire immédiatement.
+    if (remaining <= 0) {
+      removeAnimation(animation.id);
+      return;
+    }
+
     const timer = setTimeout(() => {
       removeAnimation(animation.id);
-    }, 2000);
+    }, remaining);
 
     return () => clearTimeout(timer);
-  }, [animation.id, removeAnimation]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [animation.id, elapsed]);
 
   const isPositive = animation.amount > 0;
 
@@ -52,7 +68,9 @@ export const FloatingNumber: React.FC<FloatingNumberProps> = ({ animation }) => 
       style={{
         gridRowStart: animation.row + 1,
         gridColumnStart: animation.col + 1,
-        transform: `translate(${animation.jitterX}px, ${animation.jitterY}px)`
+        transform: `translate(${animation.jitterX}px, ${animation.jitterY}px)`,
+        // Décale le début de l'animation pour reprendre là où elle en était
+        animationDelay: `${-Math.min(elapsed, DURATION_MS)}ms`
       }}
     >
       <div className="flex items-center space-x-1 font-semibold text-sm">


### PR DESCRIPTION
Resume `FloatingNumber` animations on component remount to prevent restarts on page changes.

The `FloatingNumber` component was re-rendering and restarting its CSS animation whenever the page changed, leading to a jarring user experience. By calculating the elapsed time since the animation's creation and applying a negative `animationDelay`, the animation now appears to continue seamlessly from where it left off. The cleanup timeout is also adjusted to match the remaining animation duration.

---
<a href="https://cursor.com/background-agent?bcId=bc-3064a361-e100-480b-9bfb-86159d16e837">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3064a361-e100-480b-9bfb-86159d16e837">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>