### PR TITLE
ci: tag-only signed build + modernize actions (v3 → v4)

### DIFF
--- a/.github/workflows/aab-signed.yml
+++ b/.github/workflows/aab-signed.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Cache Node Modules
       - name: Cache Node Modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.npm
@@ -32,7 +32,7 @@ jobs:
 
       # Cache Gradle (étendu)
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -46,7 +46,7 @@ jobs:
 
       # Cache du build Android
       - name: Cache Android Build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: android/app/build
           key: android-build-${{ runner.os }}-${{ github.ref_name }}
@@ -120,7 +120,7 @@ jobs:
 
       # Upload vers la release
       - name: Upload AAB and APK to GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG_NAME }}
           name: "Build ${{ env.TAG_NAME }}"

--- a/.github/workflows/aab-signed.yml
+++ b/.github/workflows/aab-signed.yml
@@ -3,7 +3,8 @@ name: Build Signed Android AAB & APK
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -103,14 +104,18 @@ jobs:
           mv android/app/build/outputs/bundle/release/app-release.aab builds/IdleGrow.aab
           mv android/app/build/outputs/apk/release/app-release.apk builds/IdleGrow.apk
 
-      # Toujours générer un tag unique
-      - name: Tag commit
+      # If triggered by a tag push, reuse it. On workflow_dispatch, mint one.
+      - name: Determine tag
         run: |
-          TAG_NAME="v${{ github.run_number }}-$(echo $GITHUB_SHA | cut -c1-7)"
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git tag "$TAG_NAME" -f
-          git push origin "$TAG_NAME" -f
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            TAG_NAME="${{ github.ref_name }}"
+          else
+            TAG_NAME="v${{ github.run_number }}-$(echo $GITHUB_SHA | cut -c1-7)"
+            git config user.name "GitHub Actions"
+            git config user.email "actions@github.com"
+            git tag "$TAG_NAME" -f
+            git push origin "$TAG_NAME" -f
+          fi
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
 
       # Upload vers la release

--- a/.github/workflows/publish-playstore.yml
+++ b/.github/workflows/publish-playstore.yml
@@ -24,7 +24,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get latest release tag
         id: get_release


### PR DESCRIPTION
Two related cleanups on the workflows.

## 1. Build signed AAB/APK on tag push, not every main commit
`aab-signed.yml` was the heaviest recurring cost: a full Android SDK setup + **two full Gradle release builds** (`bundleRelease` then `assembleRelease`) on every push to `main`. Roughly 10–15 minutes per commit, signed every time.

- Trigger swapped from `push: branches: [main]` → `push: tags: ['v*']`
- `workflow_dispatch` kept for ad-hoc manual builds
- Tagging logic adapted: when triggered by a tag push, reuse `github.ref_name`. When triggered manually via `workflow_dispatch`, mint a tag from `github.run_number` as before.

## 2. Bump actions to v4 (uniformize with hey-stream / hey-torrent)
- `actions/checkout@v3` → `@v4` (both workflows)
- `actions/cache@v3` → `@v4` (3 occurrences in `aab-signed.yml`)
- `softprops/action-gh-release@v1` → `@v2`

`actions/cache@v3` and `actions/checkout@v3` are on the deprecation track at GitHub — keeping them was a latent risk. The v4 line is what `hey-stream` and `hey-torrent` already use.

Untouched: `r0adkll/upload-google-play@v1` (still the maintained version).

## Effect on workflow
- Day-to-day commits to `main` no longer trigger a signed build — Actions minutes drop dramatically
- To cut a release: `git tag v1.0.42 && git push origin v1.0.42`
- Or use the "Run workflow" button in the Actions tab for an unscheduled build

`publish-playstore.yml` (which downloads the AAB from the GitHub Release) keeps working — it only depends on a release existing, not on how it was triggered.

## Test plan
- [ ] Merge to main → no build kicks off
- [ ] Push tag `v0.0.x-test` → build runs, signs, and uploads to a GitHub Release with that exact tag
- [ ] Run workflow manually from the Actions UI → build runs and creates a `v<run>-<sha>` tag + release
- [ ] Confirm no deprecation warning about checkout/cache v3 in the run logs